### PR TITLE
Fix path-aware searching in MRFI minibuffer

### DIFF
--- a/mrfi.el
+++ b/mrfi.el
@@ -229,19 +229,18 @@ Return the full path."
          (w-date  (nth 3 ws))
          (candidates
           (mapcar
-           (lambda (p)
-             (let* ((fi   (mrfi--file-info p))
-                    (name (plist-get fi :name))
-                    (key  (if mrfi-search-in-path
+          (lambda (p)
+            (let* ((fi   (mrfi--file-info p))
+                   (name (plist-get fi :name))
+                   (key  (if mrfi-search-in-path
                               (concat (plist-get fi :alias)
                                       (plist-get fi :rel)
                                       name)
                             name)))
-               (propertize name
+               (propertize key
                            'face 'mrfi-name-face
                            'mrfi-path p
                            'mrfi-fi fi
-                           'completion-search-key key
                            'display (mrfi--pad name w-name))))
            mrfi--cache))
          (annotation


### PR DESCRIPTION
## Summary
- Ensure minibuffer candidate search uses alias and relative path when `mrfi-search-in-path` is non-nil

## Testing
- `emacs --batch -Q -L . --eval "(byte-compile-file \"mrfi.el\")"`


------
https://chatgpt.com/codex/tasks/task_e_68a485b9a7ac83218265a1207bfbf341